### PR TITLE
Temporary github reading friendly version of code of conduct

### DIFF
--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -1,47 +1,54 @@
-*For the Horde Code of Conduct*
+# For the Horde Code of Conduct
 
-Like the technical and startup community as a whole, the For the Horde Community is made up of a mixture of people from all over the North and beyond. We are coders, freelancers, designers, startup founders, and every other flavor of geek you can imagine.  We are here for mentorship, help, support, to connect with people who can help us further our journey, and of course, to learn about the latest animated cat GIFs and maximize our emoji skill.
+Like the technical and startup community as a whole, the For the Horde Community is made up of a mixture of people from all over the North and beyond. We are coders, freelancers, designers, startup founders, and every other flavor of geek you can imagine. We are here for mentorship, help, support, to connect with people who can help us further our journey, and of course, to learn about the latest animated cat GIFs and maximize our emoji skill.
 
-Diversity is one of our huge strengths, but it can require a bit of extra consideration and empathy to make sure everyone has a good experience. To that end, we have a few ground rules that we ask people to adhere to. This code applies equally to ALL community members, including For the Horde Community admins.
-This isn’t an exhaustive list of things that you can’t do. Rather, take it in the spirit in which it’s intended - a guide to make it easier to enrich all of us and the communities in which we participate.
+Diversity is one of our huge strengths, but it can require a bit of extra consideration and empathy to make sure everyone has a good experience. To that end, we have a few ground rules that we ask people to adhere to. This code applies equally to ALL community members, including For the Horde Community admins. This isn’t an exhaustive list of things that you can’t do. Rather, take it in the spirit in which it’s intended - a guide to make it easier to enrich all of us and the communities in which we participate.
 
 This code of conduct applies to all spaces managed by the For the Horde Community. This includes Slack, For the Horde events, and any other forums created by the Community which the Community uses for communication. In addition, violations of this code outside these spaces may affect a person's ability to participate within them.
 
 If you believe someone is violating the code of conduct, we ask that you report it by contacting one of the admin Community members below.
 
-• *Be friendly and patient.*
+#### Be friendly and patient
 
-• *Be welcoming.* We strive to be a community that welcomes and supports people of all backgrounds and identities. This includes, but is not limited to members of any race, ethnicity, culture, national origin, color, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.
+#### Be welcoming
 
-• *Be considerate and respectful.* Not all of us will agree all the time, but disagreement is no excuse for poor behavior and poor manners. We might all experience some frustration now and then, but we cannot allow that frustration to turn into a personal attack. It’s important to remember that a community where people feel uncomfortable or threatened is not a productive one. Members of the For the Horde community should be respectful when dealing with other members as well as with people outside the For the Horde community.
+We strive to be a community that welcomes and supports people of all backgrounds and identities. This includes, but is not limited to members of any race, ethnicity, culture, national origin, color, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.
 
-• *Be careful in the words that you choose.* We are a community of professionals, and we conduct ourselves professionally. Be kind to others. Do not insult or put down other participants. Harassment and other exclusionary behavior aren't acceptable.
+#### Be considerate and respectful
 
-> This includes, but is not limited to:
-> • Violent threats or language directed against another person.
-> • Discriminatory jokes and language.
-> • Posting sexually explicit or violent material.
-> • Posting (or threatening to post) other people's personally identifying information ("doxing").
-> • Personal insults, especially those using racist or sexist terms.
-> • Unwelcome sexual attention.
-> • Advocating for, or encouraging, any of the above behavior.
-> • Repeated harassment of others.
+Not all of us will agree all the time, but disagreement is no excuse for poor behavior and poor manners. We might all experience some frustration now and then, but we cannot allow that frustration to turn into a personal attack. It’s important to remember that a community where people feel uncomfortable or threatened is not a productive one. Members of the For the Horde community should be respectful when dealing with other members as well as with people outside the For the Horde community.
 
-> *In general, if someone asks you to stop, then stop.*
+#### Be careful in the words that you choose.
 
-• *When we disagree, try to understand why.* Disagreements, both social and technical, happen all the time and For the Horde is no exception. It is important that we resolve disagreements and differing views constructively and respectfully. Remember that we’re different. The strength of For the Horde community comes from its varied community, people from a wide range of backgrounds. Different people have different perspectives on issues. Being unable to understand why someone holds a viewpoint doesn’t mean that they’re wrong. Don’t forget that it is human to err and blaming each other doesn’t get us anywhere. Instead, focus on helping to resolve issues and learning from mistakes.
+We are a community of professionals, and we conduct ourselves professionally. Be kind to others. Do not insult or put down other participants. Harassment and other exclusionary behavior aren't acceptable.
 
-*Need to Report a Violation or Have a Question?*
+This includes, but is not limited to: 
+
+- Violent threats or language directed against another person.
+- Discriminatory jokes and language.
+- Posting sexually explicit or violent material.
+- Posting (or threatening to post) other people's personally identifying information ("doxing").
+- Personal insults, especially those using racist or sexist terms.
+- Unwelcome sexual attention. • Advocating for, or encouraging, any of the above behavior. 
+- Repeated harassment of others.
+
+In general, if someone asks you to stop, then stop.
+
+#### When we disagree, try to understand why.
+
+Disagreements, both social and technical, happen all the time and For the Horde is no exception. It is important that we resolve disagreements and differing views constructively and respectfully. Remember that we’re different. The strength of For the Horde community comes from its varied community, people from a wide range of backgrounds. Different people have different perspectives on issues. Being unable to understand why someone holds a viewpoint doesn’t mean that they’re wrong. Don’t forget that it is human to err and blaming each other doesn’t get us anywhere. Instead, focus on helping to resolve issues and learning from mistakes.
+
+#### Need to Report a Violation or Have a Question?
 
 Please contact one of the following For the Horde admin Community members:
 
-• Jenna Pederson - @jennapederson
-• Matt Decuir - @experimatt
-• Ian Fitzpatrick - @ian
-• Aneela Kumar - @aneela
-• Shane Ewert - @shane
-• Justin Cardinal - @justin
-• Robert Nelson - @robert
-• Jake Good - @whoisjake
+- Jenna Pederson @jennapederson
+- Matt Decuir @experimatt
+- Ian Fitzpatrick @ian
+- Aneela Kumar @aneela
+- Shane Ewert @shane
+- Justin Cardinal @justin
+- Robert Nelson @robert
+- Jake Good @whoisjake
 
-This Code of Conduct was adapted from Django Code of conduct: https://www.djangoproject.com/conduct/.
+This Code of Conduct was adapted from Django Code of conduct: https://www.djangoproject.com/conduct/


### PR DESCRIPTION
The idea here is since we just blasted out the Code of Conduct to everyone, let's temporarily create any easy to read, Github Markdown-friendly version.
